### PR TITLE
改行コード/r/nを/nに修正

### DIFF
--- a/batch/scripts/notionSlack.js
+++ b/batch/scripts/notionSlack.js
@@ -31,7 +31,7 @@ const chat_postMessage = function(userToken, user) {
       // なぜか改行コードが入るため削除する
       token: userToken.replace(/\r?\n/g, ''),
       channel: user,
-      text: 'プロジェクトの終焉が近づいています。\r\n 総務部への定期券代の申請は済んでいますか。\r\n \r\n 以下のURLから定期券代の申請を行うか\r\nプロジェクト退出予定日を更新してください。\r\nhttps://xxxxx.xxxx.xxx/xxxxx'
+      text: 'プロジェクトの終焉が近づいています。\n 総務部への定期券代の申請は済んでいますか。\n \n 以下のURLから定期券代の申請を行うか\nプロジェクト退出予定日を更新してください。\nhttps://xxxxx.xxxx.xxx/xxxxx'
     }
   };
   return ret;


### PR DESCRIPTION
/r/nでも問題なく動作しましたが、/nでもLinux（検証環境）、ローカル環境のどちらでも正常に動作します。

一応l、最終的にlinux環境で動作するので/nに修正しました。
修正不要なら取り下げてください。